### PR TITLE
change 'typename' into 'class' for template template parameters

### DIFF
--- a/ot/iterated.h
+++ b/ot/iterated.h
@@ -5,7 +5,7 @@
     @{
   */
   
-template<typename IO, template<typename> typename OTExtension>
+template<typename IO, template<typename> class OTExtension>
 class OTIterated: public OT<OTIterated<IO, OTExtension>> { public:
 	OTExtension<IO> *seed_ot;
 	OTExtension<IO> *ot;

--- a/test/iter_ot.cpp
+++ b/test/iter_ot.cpp
@@ -4,7 +4,7 @@
 #include <iostream>
 using namespace std;
 
-template<typename IO, template<typename> typename T>
+template<typename IO, template<typename> class T>
 double test_ot(IO * io, int party, int length, T<IO>* ot, int TIME = 10) {
 	block *b0 = new block[length], *b1 = new block[length], *r = new block[length];
 	PRG prg(fix_key);

--- a/test/mot.cpp
+++ b/test/mot.cpp
@@ -4,7 +4,7 @@
 #include <iostream>
 using namespace std;
 
-template<typename IO, template<typename>typename T>
+template<typename IO, template<typename>class T>
 double test_com_ot(IO * io, int party, int length, T<IO>* ot = nullptr, int TIME = 10) {
 	block *b0 = new block[length], *b1 = new block[length], *r = new block[length], *op = new block[length];
 	bool *b = new bool[length];
@@ -48,7 +48,7 @@ double test_com_ot(IO * io, int party, int length, T<IO>* ot = nullptr, int TIME
 }
 
 
-template<typename IO, template<typename>typename T>
+template<typename IO, template<typename>class T>
 double test_ot(IO * io, int party, int length, T<IO>* ot = nullptr, int TIME = 10) {
 	block *b0 = new block[length], *b1 = new block[length], *r = new block[length];
 	bool *b = new bool[length];
@@ -81,7 +81,7 @@ double test_ot(IO * io, int party, int length, T<IO>* ot = nullptr, int TIME = 1
 	delete[] b;
 	return (double)t/TIME;
 }
-template<typename IO, template<typename>typename T>
+template<typename IO, template<typename>class T>
 double test_cot(IO * io, int party, int length, T<IO>* ot = nullptr, int TIME = 10) {
 	block *b0 = new block[length], *r = new block[length];
 	bool *b = new bool[length];
@@ -123,7 +123,7 @@ double test_cot(IO * io, int party, int length, T<IO>* ot = nullptr, int TIME = 
 	return (double)t/TIME;
 }
 
-template<typename IO, template<typename>typename T>
+template<typename IO, template<typename>class T>
 double test_rot(NetIO * io, int party, int length, T<IO>* ot = nullptr, int TIME = 10) {
 	block *b0 = new block[length], *r = new block[length];
 	block *b1 = new block[length];

--- a/test/shot.cpp
+++ b/test/shot.cpp
@@ -4,7 +4,7 @@
 #include <iostream>
 using namespace std;
 
-template<typename IO, template<typename>typename T>
+template<typename IO, template<typename>class T>
 double test_ot(IO * io, int party, int length, T<IO>* ot = nullptr, int TIME = 10) {
 	block *b0 = new block[length], *b1 = new block[length], *r = new block[length];
 	PRG prg(fix_key);
@@ -39,7 +39,7 @@ double test_ot(IO * io, int party, int length, T<IO>* ot = nullptr, int TIME = 1
 	delete[] b;
 	return (double)t/TIME;
 }
-template<typename IO, template<typename>typename T>
+template<typename IO, template<typename>class T>
 double test_cot(NetIO * io, int party, int length, T<IO>* ot = nullptr, int TIME = 10) {
 	block *b0 = new block[length], *r = new block[length];
 	bool *b = new bool[length];
@@ -81,7 +81,7 @@ double test_cot(NetIO * io, int party, int length, T<IO>* ot = nullptr, int TIME
 	return (double)t/TIME;
 }
 
-template<typename IO, template<typename>typename T>
+template<typename IO, template<typename>class T>
 double test_rot(IO * io, int party, int length, T<IO>* ot = nullptr, int TIME = 10) {
 	block *b0 = new block[length], *r = new block[length];
 	block *b1 = new block[length];


### PR DESCRIPTION
Solve the following warnings on macOS with clang:

```
warning: template template parameter using 'typename' is a C++1z extension
      [-Wc++1z-extensions]
```

See https://stackoverflow.com/questions/24081405/why-does-not-a-template-template-parameter-allow-typename-after-the-parameter