### PR TITLE
Flush at the end of `got/cot_send_post`

### DIFF
--- a/emp-ot/shextension.h
+++ b/emp-ot/shextension.h
@@ -34,6 +34,7 @@ class SHOTExtension: public OTExtension<IO, OTNP, emp::SHOTExtension>{ public:
 			}
 			io->send_data(pad, 2*sizeof(block)*min(bsize,length-i));
 		}
+		io->flush();
 		delete[] qT;
 	}
 
@@ -68,6 +69,7 @@ class SHOTExtension: public OTExtension<IO, OTNP, emp::SHOTExtension>{ public:
 			}
 			io->send_data(tmp, sizeof(block)*min(bsize,length-i));
 		}
+		io->flush();
 		delete[] qT;
 	}
 


### PR DESCRIPTION
In an experiment that replaced `emp-agmpc`'s OT protocol from `deltaot` to this, we discovered that it is necessary to flush after the finishing of OT, otherwise the program might get stuck.