### PR TITLE
fixes index error on OT receive during committing malicious ot extension

### DIFF
--- a/emp-ot/mextension.h
+++ b/emp-ot/mextension.h
@@ -105,7 +105,7 @@ class MOTExtension: public OTExtension<IO, OTCO, emp::MOTExtension> { public:
 				else tccrh.Hn(tT+i, tT+i, i, length -i);
 
 				for(int j = i; j < i+bsize and j < length; ++j) {
-					if (r[i]) {
+					if (r[j]) {
 						data[j] = xorBlocks(tT[j], pad1[j-i]);
 						open_data[i] = pad0[j-i];
 					}


### PR DESCRIPTION
Malicious OT extension with committing has the following bug:
The receiver currently attempts to decrypt the same index for every message in the same block.
This is due to a simple typo. (Compare lines 108 and 126)