### PR TITLE
Fix a memory leak in OTCO and indentation in MOT test

### DIFF
--- a/emp-ot/co.h
+++ b/emp-ot/co.h
@@ -59,8 +59,8 @@ class OTCO: public OT<OTCO<IO>> { public:
 	void recv_impl(block* data, const bool* b, int length) {
 		BigInt * bb = new BigInt[length];
 		Point * B = new Point[length],
-				* As = new Point[length],
-				A;
+			* As = new Point[length],
+			A;
 
 		for(int i = 0; i < length; ++i)
 			G->get_rand_bn(bb[i]);
@@ -86,7 +86,8 @@ class OTCO: public OT<OTCO<IO>> { public:
 			else
 				data[i] = xorBlocks(data[i], res[0]);
 		}
-		
+
+		delete[] As;
 		delete[] bb;
 		delete[] B;
 	}

--- a/test/mot.cpp
+++ b/test/mot.cpp
@@ -51,5 +51,5 @@ int main(int argc, char** argv) {
 	cout <<"COOT\t"<<10000.0/test_ot<NetIO, OTCO>(io, party, 10000)*1e6<<" OTps"<<endl;
 	cout <<"Malicious OT Extension\t"<<double(length)/test_ot<NetIO, MOTExtension>(io, party, length)*1e6<<" OTps"<<endl;
 	cout <<"Malicious COT Extension\t"<<double(length)/test_cot_mal<NetIO, MOTExtension>(io, party, length)*1e6<<" OTps"<<endl;
-   cout <<"Malicious ROT Extension\t"<<double(length)/test_rot<NetIO, MOTExtension>(io, party, length)*1e6<<" OTps"<<endl;
+	cout <<"Malicious ROT Extension\t"<<double(length)/test_rot<NetIO, MOTExtension>(io, party, length)*1e6<<" OTps"<<endl;
 }


### PR DESCRIPTION
`As` was not deleted, per Valgrind.