### PR TITLE
Eliminate delete_array_null

### DIFF
--- a/emp-ot/deltaot.h
+++ b/emp-ot/deltaot.h
@@ -94,15 +94,15 @@ public:
 	block * out = nullptr;
 	~DeltaOT() {
 		delete base_ot;
-		delete_array_null(s);
-		delete_array_null(G0);
-		delete_array_null(G1);
+		delete[] s;
+		delete[] G0;
+		delete[] G1;
 		afree(this->t);
 		afree(this->tT);
 		afree(k0);
 		afree(k1);
 		afree(tmp);
-		delete_array_null(extended_r);
+		delete[] extended_r;
 	}
 
 	void bool_to256(const bool * in, block res[2]) {
@@ -171,7 +171,7 @@ public:
 
 		bool * r2 = new bool[length];
 		memcpy(r2, r, old_length);
-		delete_array_null(extended_r);
+		delete[] extended_r;
 		extended_r = new bool[length - old_length];
 		prg.random_bool(extended_r, length- old_length);
 		memcpy(r2+old_length, extended_r, length - old_length);

--- a/emp-ot/mextension.h
+++ b/emp-ot/mextension.h
@@ -30,7 +30,7 @@ class MOTExtension: public OTExtension<IO, OTCO, emp::MOTExtension> { public:
 		}
 
 	~MOTExtension() {
-		delete_array_null(open_data);
+		delete[] open_data;
 	}
 
 	bool send_check(int length) {
@@ -96,7 +96,7 @@ class MOTExtension: public OTExtension<IO, OTCO, emp::MOTExtension> { public:
 		block pad0[bsize];
 		block pad1[bsize];
 		if(committing) {
-			delete_array_null(open_data);
+			delete[] open_data;
 			open_data = new block[length];
 			for(int i = 0; i < length; i+=bsize) {
 				io->recv_data(pad0, sizeof(block)*min(bsize,length-i));


### PR DESCRIPTION
It's functionally equivalent to [delete[]](https://en.cppreference.com/w/cpp/language/delete), except in the edge case of a null pointer where there is a user-defined deallocation/delete operator that actually does something. In particular, scope rules [don't get changed](http://www.cplusplus.com/forum/general/88491/) for inline functions, so zeroing out the pointers does nothing.