### PR TITLE
rcot inplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ Active IKNP OT	Tests passed.	1.39589e+07 OTps
 Active IKNP COT	Tests passed.	2.42705e+07 OTps
 Active IKNP ROT	Tests passed.	1.47379e+07 OTps
 Passive FERRET OT	Tests passed.	1.36986e+07 OTps
-Passive FERRET COT	Tests passed.	2.73098e+07 OTps
+Passive FERRET COT	Tests passed.	3.34741e+07 OTps
 Passive FERRET ROT	Tests passed.	1.82382e+07 OTps
 Active FERRET OT	Tests passed.	1.32552e+07 OTps
-Active FERRET COT	Tests passed.	2.5998e+07 OTps
+Active FERRET COT	Tests passed.	3.13997e+07 OTps
 Active FERRET ROT	Tests passed.	1.79005e+07 OTps
 
 Active FERRET: 6.05e+07 RCOT per second

--- a/emp-ot/ferret/ferret_cot.h
+++ b/emp-ot/ferret/ferret_cot.h
@@ -23,7 +23,7 @@ public:
 	int n_pre, t_pre, k_pre, log_bin_sz_pre;
 	int ot_used, ot_limit;
 
-	FerretCOT(int party, T * ios[threads+1], bool malicious = false);
+	FerretCOT(int party, T * ios[threads+1], bool malicious = false, std::string pre_file="");
 
 	~FerretCOT();
 
@@ -31,13 +31,11 @@ public:
 
 	void recv_cot(block* data, const bool * b, int length) override;
 
-	void setup(block Deltain, std::string pre_file="");
-
-	void setup(std::string pre_file="");
-
 	void rcot(block *data, int num);
 
-	void rcot_inplace(block *ot_buffer, int length);
+	uint64_t rcot_inplace(block *ot_buffer, int length);
+
+	uint64_t byte_memory_need_inplace(uint64_t ot_need);
 
 private:
 	block ch[2];
@@ -61,6 +59,10 @@ private:
 	ThreadPool *pool = nullptr;
 	MpcotReg<threads> *mpcot = nullptr;
 	LpnF2<10> *lpn_f2 = nullptr;
+
+	void setup(block Deltain, std::string pre_file);
+
+	void setup(std::string pre_file);
 
 	void online_sender(block *data, int length);
 

--- a/test/ferret.cpp
+++ b/test/ferret.cpp
@@ -19,20 +19,22 @@ void test_ferret(int party, NetIO *ios[threads+1]) {
 	std::cout << party << "\tCOT\t" << timeused/1000 << "ms" << std::endl;
 	delete[] ot_data_alloc;
 
-	num = 3*ferretcot->ot_limit+ferretcot->n_pre;
-	ot_data_alloc = new block[num];
-	std::cout << "\ngenerating " << num << " COTs inplace: " << std::endl;
+	num = 3*ferretcot->ot_limit;
+	uint64_t memory_len = ferretcot->byte_memory_need_inplace((uint64_t)num);
+	ot_data_alloc = new block[memory_len];
+	std::cout << "\ngenerating " << memory_len - ferretcot->n_pre << " COTs inplace: " << std::endl;
 	start = clock_start();
-	ferretcot->rcot_inplace(ot_data_alloc, num);
+	uint64_t ot_output_n = ferretcot->rcot_inplace(ot_data_alloc, memory_len);
 	timeused = time_from(start);
-	std::cout << party << "\tCOT emplace\t" << timeused/1000 << "ms" << std::endl;
+	std::cout << party << "\t" << ot_output_n << " COT emplace\t" << timeused/1000 << "ms" << std::endl;
 	delete[] ot_data_alloc;
 
-	num = ferretcot->n;
-	ot_data_alloc = new block[num];
+	num = ferretcot->ot_limit;
+	memory_len = ferretcot->byte_memory_need_inplace((uint64_t)num);
+	ot_data_alloc = new block[memory_len];
 	std::cout << "\nefficiency benchmark: " << std::endl;
 	start = clock_start();
-	ferretcot->rcot_inplace(ot_data_alloc, num);
+	ferretcot->rcot_inplace(ot_data_alloc, memory_len);
 	timeused = time_from(start);
 	std::cout << party << "\t[benchmark] time per COT element\t" << timeused*1000/ferretcot->ot_limit << "ns" << std::endl;
 	delete[] ot_data_alloc;


### PR DESCRIPTION
A member function that generates r-cot directly in a given buffer. This avoids the step of memory copy from the internal buffer to the user's buffer.