### PR TITLE
Fix template parameters in ```lpn_f2.h```

### DIFF
--- a/emp-ot/ferret/lpn_f2.h
+++ b/emp-ot/ferret/lpn_f2.h
@@ -29,10 +29,10 @@ class LpnF2 { public:
 	}
 
 	void __compute4(block * nn, const block * kk, int64_t i, PRP * prp) {
-		block tmp[10];
-		for(int m = 0; m < 10; ++m)
+		block tmp[d];
+		for(int m = 0; m < d; ++m)
 			tmp[m] = makeBlock(i, m);
-		AES_ecb_encrypt_blks(tmp, 10, &prp->aes);
+		AES_ecb_encrypt_blks(tmp, d, &prp->aes);
 		uint32_t* r = (uint32_t*)(tmp);
 		for(int m = 0; m < 4; ++m)
 			for (int j = 0; j < d; ++j) {
@@ -44,10 +44,11 @@ class LpnF2 { public:
 	}
 
 	void __compute1(block * nn, const block * kk, int64_t i, PRP*prp) {
-		block tmp[3];
-		for(int m = 0; m < 3; ++m)
+                const auto nr_blocks = d/4 + (d % 4 != 0);
+                block tmp[nr_blocks];
+		for(int m = 0; m < nr_blocks; ++m)
 			tmp[m] = makeBlock(i, m);
-		prp->permute_block(tmp, 3);
+		prp->permute_block(tmp, nr_blocks);
 		uint32_t* r = (uint32_t*)(tmp);
 		for (int j = 0; j < d; ++j)
 			nn[i] = nn[i] ^ kk[r[j]%k];


### PR DESCRIPTION
At the moment the ```lpn_f2.h``` file seems to implicitly assume that ```d==10``` is always true:

https://github.com/emp-toolkit/emp-ot/blob/0c29cb878de2b19c3496751cf1f05f15d4e07a15/emp-ot/ferret/lpn_f2.h#L32

However, this may cause crashes if ```d``` isn't actually 10:

https://github.com/emp-toolkit/emp-ot/blob/0c29cb878de2b19c3496751cf1f05f15d4e07a15/emp-ot/ferret/lpn_f2.h#L38

To see this, notice that the loop reads a single unsigned integer per iteration from each block. Each block is treated as 4 unsigned integers, leading to 40 unsigned integers in total. However, if ```d``` isn't 10, then the loop will read either fewer than 40 integers (the safe case) or more than 40 integers (the unsafe case).

There's a similar issue in ```__compute1```, too.
https://github.com/emp-toolkit/emp-ot/blob/0c29cb878de2b19c3496751cf1f05f15d4e07a15/emp-ot/ferret/lpn_f2.h#L47

This PR fixes these by replacing the explicit ```10``` with ```d```. I've applied a similar fix to ```__compute1```: there, ```d``` integers are used, and so we need ```d/4 + (d%4 != 0)``` blocks. 