### PR TITLE
Fix Multithread Indexing in Lpn Computation

### DIFF
--- a/emp-ot/ferret/lpn_f2.h
+++ b/emp-ot/ferret/lpn_f2.h
@@ -75,7 +75,7 @@ class LpnF2 { public:
 			}));
 		}
 		int64_t start = (threads - 1) * width;
-		int64_t end = min(threads * width, n);
+        	int64_t end = n;
 		task(nn, kk, start, end);
 
 		for (auto &f: fut) f.get();
@@ -103,7 +103,7 @@ class LpnF2 { public:
 			}));
 		}
 		int64_t start = (threads - 1) * width;
-		int64_t end = min(threads * width, n);
+        	int64_t end = n;
 		task(nn, kk, start, end);
 
 		for (auto &f: fut) f.get();


### PR DESCRIPTION
This commit addresses a bug in the original indexing that caused the last `n%thread` elements to be skipped during computation. Now the last thread will compute `width + n%thread` elements.